### PR TITLE
Nuxt 3 でESLint が素直に動かない問題があるのを修正

### DIFF
--- a/src/repositories/eslint.spec.ts
+++ b/src/repositories/eslint.spec.ts
@@ -44,7 +44,7 @@ describe('🚓 ESLintRc', () => {
   });
 
   describe('🚓 enableNuxtAndTypeScriptFeatures', () => {
-    it('👮‍ 実行すると extends が設定される', () => {
+    it('👮‍ 実行すると extends が設定される. parser は 空になる', () => {
       const eslintrc = new ESLintRc();
       eslintrc.enableNuxtAndTypeScriptFeatures();
 
@@ -53,6 +53,7 @@ describe('🚓 ESLintRc', () => {
       };
 
       expect(eslintrc.config.extends).toStrictEqual(expectResults.extends);
+      expect(eslintrc.config.parser).toBe(undefined);
     });
   });
 

--- a/src/repositories/eslint.ts
+++ b/src/repositories/eslint.ts
@@ -97,6 +97,13 @@ export class ESLintRc implements Toolchain {
     if (Array.isArray(this.config.extends)) {
       this.config.extends.push('@nuxtjs/eslint-config-typescript');
     }
+
+    // parser のオプションがあると vue ファイルの検査でエラーになるので排除
+    this.config = Object.fromEntries(
+      Object.entries(this.config).filter(([key]) => {
+        return key !== 'parser';
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
# Referenced issue

<!-- 関連Issueがあれば -->

- close #213

# やったこと

<!-- このPRで実施した事項を並べる -->

- parser のオプション設定があると Vue ファイルの検査に対してエラーになることがわかったので直した

# その他

<!-- 注意事項など -->

# チェック項目

- [x] ちゃんとテストを書きましたか？
- [x] linter の警告はありませんか？
- [x] `yarn lint:fix` でコードフォーマットを修正しましたか？
